### PR TITLE
Moved bind9 from network to services

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ pages:
     - Project Ideas: plans/project-ideas.md
   - Services:
     - Bitlbee: services/bitlbee.md
+    - Bind9: services/bind9.md
     - Dovecot: services/dovecot.md
     - hey: services/hey.md
     - IRC: services/irc.md
@@ -64,7 +65,6 @@ pages:
     - Metharme: machines/metharme.md
     - Zeus: machines/zeus.md
   - Network:
-    - Bind9: network/bind9.md
     - Cisco iOS: network/ciscoios.md
     - Hadron: network/hadron.md
     - Higgs: network/higgs.md


### PR DESCRIPTION
This seems like a more appropriate location, as "discussed" in https://github.com/redbrick/docs/issues/7.