### PR TITLE
Removed paragraph about docuwiki migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Documentation for [Redbrick](https://redbrick.dcu.ie)
 
-Migrated from [dokuwiki](https://docs.redbrick.dcu.ie) to [readthedocs](http://redbrick.readthedocs.io)
+Available at https://docs.redbrick.dcu.ie and at the (readthedocs mirror)[https://redbrick.readthedocs.io]
 
 The docs are built using mkdocs.
 To bring up a local server with a copy of the docs just run

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Documentation for [Redbrick](https://redbrick.dcu.ie)
 
-Available at https://docs.redbrick.dcu.ie and at the (readthedocs mirror)[https://redbrick.readthedocs.io]
+Available at (docs.redbrick.dcu.ie)[https://docs.redbrick.dcu.ie] and at the (readthedocs mirror)[https://redbrick.readthedocs.io]
 
 The docs are built using mkdocs.
 To bring up a local server with a copy of the docs just run


### PR DESCRIPTION
The docs site reflects the latest changes from the repository, no longer being hosted by docuwiki.