### PR TITLE
pin mkdocs and read the docs config to ensure builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,14 @@
+---
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+build:
+  image: latest
+  fail_on_warning: false
+mkdocs:
+  configuration: mkdocs.yml
+formats: all
+python:
+  version: 3.7
+  install:
+    - requirements: requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs
-pymdown-extensions
+mkdocs>=1.0.4
+pymdown-extensions>=6.1


### PR DESCRIPTION
i noticed that mkdocs has been failing to build for a while on read the docs this is likely related to an mkdocs version mismatch so pinning mkdocs version 