### PR TITLE
Add config location for www.redbrick.dcu.ie

### DIFF
--- a/docs/web/redbrick.dcu.ie.md
+++ b/docs/web/redbrick.dcu.ie.md
@@ -16,6 +16,14 @@ redirects all traffic to www subdomain
 redirect 301 / https://www.redbrick.dcu.ie
 ```
 
+## Apache Config 
+
+The config file for www.redbrick.dcu.ie can be found on Metharme.
+
+```
+/etc/apache2/sites-enabled/000-ssl
+```
+
 ## SSL Oddity
 
 Because we want members to SSH to azazel but meth is the web server, Apache is


### PR DESCRIPTION
All other confs in sites-enabled / sites-available that are on the .redbrick.dcu.ie domain follow the pattern:
```
%subdomain%.redbrick.dcu.ie 
```
apart from the www, so just a nice note for future webmasters as I don't think that's normally a default for apache? 