### PR TITLE
Fix index links, update SSL docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,8 @@ work. Ever. For anything).
 
 ## Current stuff
 
-- [Current TODO list](/plans/TODO-2017)
-- [Suggested Ideas](/plans/project-ideas)
+- [Current TODO list](plans/TODO-2017)
+- [Suggested Ideas](plans/project-ideas)
 
 ---
 
@@ -19,8 +19,8 @@ work. Ever. For anything).
 You will regret this decision. But if you are sure make sure you are familiar
 with the following:
 
-- [Policies](/procedures/policies)
-- [Abuse@redbrick, and the committee stance on it](/procedures/abuse)
+- [Policies](procedures/policies)
+- [Abuse@redbrick, and the committee stance on it](procedures/abuse)
 
 ---
 
@@ -28,56 +28,56 @@ with the following:
 
 Day to day running of things.
 
-- [IRC Operator Guide](/procedures/irc_operator)
-- [IRC](/services/irc)
-- [LDAP](/services/ldap)
-- [News Server (the boards)](/services/news)
-- [Clubs and Socs Day](/procedures/rrs)
-- [Changing a local Password](/procedures/passwd)
-- [Committee changeover procedure](/procedures/committeechangeover)
-- [Installing new machines](/procedures/newinstalls)
-- [Responding to tickets](/procedures/ticketing)
+- [IRC Operator Guide](procedures/irc_operator)
+- [IRC](services/irc)
+- [LDAP](services/ldap)
+- [News Server (the boards)](services/news)
+- [Clubs and Socs Day](procedures/rrs)
+- [Changing a local Password](procedures/passwd)
+- [Committee changeover procedure](procedures/committeechangeover)
+- [Installing new machines](procedures/newinstalls)
+- [Responding to tickets](procedures/ticketing)
 
 #### Storage
 
-- [Current NFS setup](/services/nfs)
+- [Current NFS setup](services/nfs)
 
 #### Mail
 
-- [Exim email setup](/services/exim)
-- [Dovecot IMAP](/services/dovecot)
-- [Mailing Lists (Mailman)](/services/mailman)
-- [Mail setup for mutt](/procedures/mail_setup)
+- [Exim email setup](services/exim)
+- [Dovecot IMAP](services/dovecot)
+- [Mailing Lists (Mailman)](services/mailman)
+- [Mail setup for mutt](procedures/mail_setup)
 
 #### NNTP
 
-- [Setting up a new board](/procedures/newboard)
+- [Setting up a new board](procedures/newboard)
 
 #### Databases
 
-- [MySQL](/services/mysql)
-- [postgres](/services/postgres)
+- [MySQL](services/mysql)
+- [postgres](services/postgres)
 
 #### Network
 
-- [.15 Address Space](/network/mainaddressspace)
-- [Network setup](/network/networksetup) (internal LAN, external LAN, switches,
+- [.15 Address Space](network/mainaddressspace)
+- [Network setup](network/networksetup) (internal LAN, external LAN, switches,
   cable colours etc)
-- [tunnel.redbrick.dcu.ie](/services/tunnel.redbrick.dcu.ie)
-- [Switch Setup](/procedures/switch)
-- [Gratuitous ARP](/procedures/gratuitousarp) (or, how to force update an IP
+- [tunnel.redbrick.dcu.ie](services/tunnel.redbrick.dcu.ie.md)
+- [Switch Setup](procedures/switch)
+- [Gratuitous ARP](procedures/gratuitousarp) (or, how to force update an IP
   address's associated MAC on the router and other machines)
-- [JunOS Configuration](/network/junos)
+- [JunOS Configuration](network/junos)
 
 #### WWW
 
-- [Redbrick SSL certs](/procedures/ssl)
-- [Webchat (qwebirc)](/web/webchat)
+- [Redbrick SSL certs](web/ssl)
+- [Webchat (qwebirc)](web/webchat)
 
 #### Backups
 
-- [BackupPC](/services/backuppc)
-- [Moving severus to CSD](/procedures/severuscolocation)
+- [BackupPC](services/backuppc)
+- [Moving severus to CSD](procedures/severuscolocation)
 
 ---
 
@@ -85,7 +85,7 @@ Day to day running of things.
 
 After each emergency remember to write a postmortem!
 
-- [What to do immediately after a power cut](/procedures/post_powercut)
+- [What to do immediately after a power cut](procedures/post_powercut)
 
 ---
 
@@ -95,27 +95,27 @@ After each emergency remember to write a postmortem!
 
 #### Daedalus + Icarus - LDAP + Distributed storage
 
-- [LDAP](/services/ldap)
+- [LDAP](services/ldap)
 - NFS, (a.k.a /storage) from Icarus
 
 #### Paphos - Primary Services
 
-- [DNS](/services/bind9)
+- [DNS](services/bind9)
 
 #### Zeus - Secondary Services and New web
 
-- [Techweek](/web/techweek)
-- [Website](/web/website)
+- [Techweek](web/techweek)
+- [Website](web/website)
 
 #### Metharme - Web Applications
 
-- [Web Server](/web/apache)
-- [IceCast](/services/icecast2)
+- [Web Server](web/apache)
+- [IceCast](services/icecast2)
 
 #### halfpint - Admin Bastion
 
-- [DRAC Access](/procedures/dracaccess)
-- [Password Safe](/procedures/pwsafe)
+- [DRAC Access](procedures/dracaccess)
+- [Password Safe](procedures/pwsafe)
 
 ### User Login
 
@@ -123,41 +123,41 @@ After each emergency remember to write a postmortem!
 
 #### Pygmalion - User Development
 
-- [DRAC Access](/procedures/dracaccess)
+- [DRAC Access](procedures/dracaccess)
 
 ## Security
 
-- [Rootholder public keys](/procedures/gpgkeys)
+- [Rootholder public keys](procedures/gpgkeys)
 
 ## Hardware
 
 ### Switches
 
-- [Cisco IOS](/network/ciscoios)
-- [Hadron](/network/hadron)
-- [JunOS](/network/junos)
-- [Higgs](/network/higgs)
+- [Cisco IOS](network/ciscoios)
+- [Hadron](network/hadron)
+- [JunOS](network/junos)
+- [Higgs](network/higgs)
 
 ### UPS
 
-- [The PDUs](/hardware/the_pdus)
+- [The PDUs](hardware/the_pdus)
 
 ### Other
 
-- [Dell IP-KVM](/hardware/ipkvm)
+- [Dell IP-KVM](hardware/ipkvm)
 
 ## Software
 
 Software written by RedBrick, or with RedBrick customisations etc.
 
-- [RedBrick Apt Repo (work in progress)](/procedures/redbrick-apt)
-- [Backported Packages](/procedures/backport-packages)
-- [Hey (and huh)](/services/hey)
-- [Rbusers](/procedures/rbusers)
-- [Chfn & Chsh for ldap](/procedures/ldapchshchfn)
-- [Small scripts](/procedures/rbscripts)
-- [RedBrick MOTD setup](/services/unifiedmotd)
-- [Icecast Streaming Service for DCUFM](/services/icecast2)
+- [RedBrick Apt Repo (work in progress)](procedures/redbrick-apt)
+- [Backported Packages](procedures/backport-packages)
+- [Hey (and huh)](services/hey)
+- [Rbusers](procedures/rbusers)
+- [Chfn & Chsh for ldap](procedures/ldapchshchfn)
+- [Small scripts](procedures/rbscripts)
+- [RedBrick MOTD setup](services/unifiedmotd)
+- [Icecast Streaming Service for DCUFM](services/icecast2)
 
 ---
 

--- a/docs/web/ssl.md
+++ b/docs/web/ssl.md
@@ -2,9 +2,9 @@
 
 ## Background
 
-Redbrick has a wildcard ssl cert for \*.redbrick.dcu.ie, issued by The SSL
+Redbrick has a wildcard SSL cert for \*.redbrick.dcu.ie, issued by The SSL
 Store/RapidSSL. It was purchased before LetsEncrypt supported wildcard certs and
-for the sake of the price paid is being kept in use until it expires.
+for the sake of the price paid was being kept in use until it expires.
 
 At the time of writing, our cert deployment looks like so:
 
@@ -14,7 +14,6 @@ At the time of writing, our cert deployment looks like so:
 | pygmalion | /etc/apache2/ssl      | Y         | N            |
 | paphos    | /etc/apache2/ssl      | Y         | N            |
 | paphos    | /etc/dovecot/ssl      | Y         | N            |
-| azazel    | /etc/letsencrypt/live | N         | Y            |
 | hardcase  | /var/lib/acme/certs   | N         | Y            |
 
 ## NixOS and SSL Certs
@@ -99,22 +98,12 @@ you run that command, any domains which do not have certs associated with them,
 and thus have no systemd service, will fail to start. You should delete these
 folders as they are no longer used.
 
-## Other LetsEncrypt Deployments
-
-CertBot is set up on Azazel and Metharme, in `/local/usr/sbin`. It is cron'd to
-run at 02:30 and 14:30 daily and log to `/var/log/le-renew.log`. The Apache on
-Azazel is configured to use this cert for redbrick.dcu.ie and
-azazel.redbrick.dcu.ie
-
-For more configuration info on Certbot see
-[here](https://certbot.eff.org/#ubuntutrusty-apache)
-
 ## The RapidSSL Cert
 
 ### Paperwork
 
 This should be on the grant app at the start of each year, in the past it has
-not been approved. The price is \$149 for the year.
+not been approved. The price is $149 for the year.
 
 Rapidssl will email admins@rb about a month before the cert is due for renewal
 with instructions, this usually happens around April.
@@ -137,7 +126,7 @@ credentials in pwsafe under "ssl".
 #### Generating a CSR
 
 **NOTE**: You most likely do not need to do this! These instructions exist in
-the event the key and csr are lost.
+the event the key and CSR are lost.
 
 - Start generating a CSR with this command:
 
@@ -149,7 +138,7 @@ openssl req –new –newkey rsa:2048 –nodes –keyout redbrick.dcu.ie.key –
 
 | Field               | Value                               |
 | ------------------- | ----------------------------------- |
-| Common Name         | \*.redbrick.dcu.ie                  |
+| Common Name         | *.redbrick.dcu.ie                   |
 | Organization Name   | Redbrick - DCU's Networking Society |
 | Organizational Unit | Admins                              |
 | City/Locality       | Glasnevin                           |

--- a/docs/web/ssl.md
+++ b/docs/web/ssl.md
@@ -14,7 +14,7 @@ At the time of writing, our cert deployment looks like so:
 | pygmalion | /etc/apache2/ssl      | Y         | N            |
 | paphos    | /etc/apache2/ssl      | Y         | N            |
 | paphos    | /etc/dovecot/ssl      | Y         | N            |
-| hardcase  | /var/lib/acme/certs   | N         | Y            |
+| hardcase  | /var/lib/acme/        | N         | Y            |
 
 ## NixOS and SSL Certs
 
@@ -89,7 +89,7 @@ which happened us once. The fastest way to do this is by using the list
 of folders as service names and an awk script:
 
 ```bash
-cd /var/lib/acme/certs
+cd /var/lib/acme
 ls -1 | awk '{ print "acme-" $1 }' | xargs systemctl start
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,7 +62,6 @@ nav:
       - Pwsafe: procedures/pwsafe.md
       - RRS: procedures/rrs.md
       - Redbrick-apt: procedures/redbrick-apt.md
-      - SSL: procedures/ssl.md
       - Severus Colocation: procedures/severuscolocation.md
       - Switch: procedures/switch.md
       - Ticketing: procedures/ticketing.md
@@ -88,10 +87,12 @@ nav:
       - Network Setup: network/networksetup.md
   - Postmortems:
       - March 2016: postmortems/post_mortem_mar16.md
+      - Template: postmortems/template.md
   - Web:
       - Apache Modules: web/apachemodules.md
       - Apache: web/apache.md
       - PubCookie: web/pubcookie.md
+      - SSL: web/ssl.md
       - SuPHP: web/suphp.md
       - Traefik: web/traefik.md
       - TechWeek: web/techweek.md


### PR DESCRIPTION
All the index links were broke on readthedocs.io because they add `/en/latest` to the URL.

SSL docs now cover the NixOS deployment.